### PR TITLE
update README.md, simplify code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ switch(a > b, {
 	[false] = function()
 		print("hmm, didn't work!")
 	end,
-	["default"] = function()
+	default = function()
 		print("default")
 	end,
 })

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 Use switch statements in Lua!
 
 # How To Use
+
+The switch statements support two things, function calling, and returning values. If you supply a function as the value for any given key, it will call the function and return the output of that function call. If you supply anything other than a function as the value for any given key, it will return said value.
+
+## Case 1: Function calling
 ```lua
 local a = 100
 local b = 70
@@ -17,4 +21,53 @@ switch(a > b, {
 		print("default")
 	end,
 })
+```
+
+Output:
+```
+worked!
+```
+
+## Case 2: Returning values from a function call
+```lua
+local a = 100
+local b = 70
+
+local returnValue = switch(a > b, {
+	[true] = function()
+		return "worked!"
+	end,
+	[false] = function()
+		return "hmm, didn't work!"
+	end,
+	default = function()
+		return "default"
+	end,
+})
+
+print(returnValue)
+```
+
+Output:
+```
+worked!
+```
+
+## Case 3: Returning value from a non-function call
+```lua
+local a = 100
+local b = 70
+
+local returnValue = switch(a > b, {
+	[true] = "worked!";
+	[false] = "hmm, didn't work!";
+	default = "default";
+})
+
+print(returnValue)
+```
+
+Output:
+```
+worked!
 ```

--- a/switch.lua
+++ b/switch.lua
@@ -1,12 +1,7 @@
-local Switch = {}
-setmetatable(Switch, Switch)
-
-Switch.__call = function(self, condition, results)
-	local exists = results[condition] or results["default"]
-	if typeof(exists) == "function" then
+return function(condition, results)
+	local exists = results[condition] or results.default
+	if type(exists) == "function" then
 		return exists()
 	end
 	return exists
 end
-
-return Switch


### PR DESCRIPTION
The code for your switch statement uses an unnecessary metatable. This makes it harder for beginners to understand your code, and make it use more memory than it needs to.

The difference in time/memory usage between keeping and removing it it is negligible, but the metatable still becomes unnecessary.


I also changed the README to make it easier for people to understand how to use it, and the various ways you can use it. Namely, I highlighted the three different ways people can make use of it.